### PR TITLE
add IF EXISTS to drop function - so ecto.setup works

### DIFF
--- a/priv/repo/migrations/20200415184200_stored_procedures1.exs
+++ b/priv/repo/migrations/20200415184200_stored_procedures1.exs
@@ -3,7 +3,7 @@ defmodule Kandesk.Repo.Migrations.StoredProcedures1 do
 
   def change do
 execute ~S"""
-DROP FUNCTION public.sp_delete_board(bigint);
+DROP FUNCTION IF EXISTS public.sp_delete_board(bigint);
 """
 
 execute ~S"""
@@ -35,7 +35,7 @@ LANGUAGE plpgsql;
 """
 
 execute ~S"""
-DROP FUNCTION public.sp_delete_column(bigint);
+DROP FUNCTION IF EXISTS public.sp_delete_column(bigint);
 """
 
 execute ~S"""
@@ -69,7 +69,7 @@ LANGUAGE plpgsql;
 """
 
 execute ~S"""
-DROP FUNCTION public.sp_move_column(bigint, integer, integer);
+DROP FUNCTION IF EXISTS public.sp_move_column(bigint, integer, integer);
 """
 
 execute ~S"""
@@ -113,7 +113,7 @@ LANGUAGE plpgsql;
 """
 
 execute ~S"""
-DROP FUNCTION public.sp_delete_task(bigint);
+DROP FUNCTION IF EXISTS public.sp_delete_task(bigint);
 """
 
 execute ~S"""
@@ -144,7 +144,7 @@ LANGUAGE plpgsql;
 """
 
 execute ~S"""
-DROP FUNCTION public.sp_move_task(bigint, bigint, bigint, integer, integer);
+DROP FUNCTION IF EXISTS public.sp_move_task(bigint, bigint, bigint, integer, integer);
 """
 
 execute ~S"""


### PR DESCRIPTION
fixes ecto.setup issue that was giving:

21:37:43.287 [info]  == Running 20200415184200 Kandesk.Repo.Migrations.StoredProcedures1.change/0 forward

21:37:43.287 [info]  execute "DROP FUNCTION public.sp_delete_board(bigint);\n"
** (Postgrex.Error) ERROR 42883 (undefined_function) function public.sp_delete_board(bigint) does not exist

all of the IF EXISTS are probably not needed - but added them as safeguards..